### PR TITLE
Remove singleQuote override for Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,3 @@
 {
-  "singleQuote": true,
   "trailingComma": "all"
 }

--- a/e2e/tests/hello-world.test.ts
+++ b/e2e/tests/hello-world.test.ts
@@ -1,9 +1,9 @@
-import { Selector } from 'testcafe';
+import { Selector } from "testcafe";
 
-fixture`Example app`.page('http://localhost:3000');
+fixture`Example app`.page("http://localhost:3000");
 
-test('Check environment message', async (t) => {
+test("Check environment message", async (t) => {
   await t
-    .expect(Selector('div').textContent)
-    .match(new RegExp('Current environment LOCAL'));
+    .expect(Selector("div").textContent)
+    .match(new RegExp("Current environment LOCAL"));
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testResultsProcessor: 'jest-sonar-reporter',
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testResultsProcessor: "jest-sonar-reporter",
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('autoprefixer')],
+  plugins: [require("autoprefixer")],
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import WelcomeMessage from './components/WelcomeMessage';
+import * as React from "react";
+import WelcomeMessage from "./components/WelcomeMessage";
 
 const App: React.FC = () => <WelcomeMessage />;
 

--- a/src/components/WelcomeMessage/WelcomeMessage.tsx
+++ b/src/components/WelcomeMessage/WelcomeMessage.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { getConfig } from '../../utils/config-utils';
-import styles from './WelcomeMessage.module.css';
+import * as React from "react";
+import { getConfig } from "../../utils/config-utils";
+import styles from "./WelcomeMessage.module.css";
 
 interface Props {
   appName?: string;

--- a/src/components/WelcomeMessage/index.tsx
+++ b/src/components/WelcomeMessage/index.tsx
@@ -1,3 +1,3 @@
-import WelcomeMessage from './WelcomeMessage';
+import WelcomeMessage from "./WelcomeMessage";
 
 export default WelcomeMessage;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
-import './styles/variables.css';
+import "./styles/variables.css";
 
-import App from './App';
+import App from "./App";
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -4,7 +4,7 @@ declare const __BUILD_INFO__: {
   commitHash: string;
 };
 
-declare module '*.module.css' {
+declare module "*.module.css" {
   const classes: { [key: string]: string };
   export default classes;
 }

--- a/src/utils/config-utils.test.ts
+++ b/src/utils/config-utils.test.ts
@@ -1,36 +1,36 @@
-import { Environment, getEnvironment, getConfig } from './config-utils';
+import { Environment, getEnvironment, getConfig } from "./config-utils";
 
-describe('getEnvironment', () => {
+describe("getEnvironment", () => {
   test.each`
     value                               | expectedResult
-    ${'http://localhost:3000'}          | ${Environment.LOCAL}
-    ${'http://localhost:8000'}          | ${Environment.LOCAL}
-    ${'https://dev.example.com'}        | ${Environment.DEV}
-    ${'https://www.dev.example.com'}    | ${Environment.DEV}
-    ${'https://staging.example.com'}    | ${Environment.STAGING}
-    ${'https://www.staging.example.no'} | ${Environment.STAGING}
-    ${'https://example.com'}            | ${Environment.PROD}
-    ${'https://www.example.com'}        | ${Environment.PROD}
-  `('should return $expectedResult for $value', ({ expectedResult, value }) => {
+    ${"http://localhost:3000"}          | ${Environment.LOCAL}
+    ${"http://localhost:8000"}          | ${Environment.LOCAL}
+    ${"https://dev.example.com"}        | ${Environment.DEV}
+    ${"https://www.dev.example.com"}    | ${Environment.DEV}
+    ${"https://staging.example.com"}    | ${Environment.STAGING}
+    ${"https://www.staging.example.no"} | ${Environment.STAGING}
+    ${"https://example.com"}            | ${Environment.PROD}
+    ${"https://www.example.com"}        | ${Environment.PROD}
+  `("should return $expectedResult for $value", ({ expectedResult, value }) => {
     expect(getEnvironment(value)).toEqual(expectedResult);
   });
 });
 
-describe('getConfig', () => {
-  test('should fetch config for local environment', () => {
-    const config = getConfig('http://localhost:3000');
+describe("getConfig", () => {
+  test("should fetch config for local environment", () => {
+    const config = getConfig("http://localhost:3000");
 
     expect(config.environment).toBe(Environment.LOCAL);
   });
 
-  test('should fetch config for staging environment', () => {
-    const config = getConfig('https://staging.example.com');
+  test("should fetch config for staging environment", () => {
+    const config = getConfig("https://staging.example.com");
 
     expect(config.environment).toBe(Environment.STAGING);
   });
 
-  test('should fetch config for prod environment', () => {
-    const config = getConfig('https://example.com');
+  test("should fetch config for prod environment", () => {
+    const config = getConfig("https://example.com");
 
     expect(config.environment).toBe(Environment.PROD);
   });

--- a/src/utils/config-utils.ts
+++ b/src/utils/config-utils.ts
@@ -1,8 +1,8 @@
 export enum Environment {
-  LOCAL = 'LOCAL',
-  DEV = 'DEV',
-  STAGING = 'STAGING',
-  PROD = 'PROD',
+  LOCAL = "LOCAL",
+  DEV = "DEV",
+  STAGING = "STAGING",
+  PROD = "PROD",
 }
 
 interface IAppConfiguration {
@@ -16,19 +16,19 @@ type IEnvToConfigMap = {
 
 const envToConfigMap: IEnvToConfigMap = {
   [Environment.LOCAL]: {
-    apiUrl: 'http://localhost:8080',
+    apiUrl: "http://localhost:8080",
     environment: Environment.LOCAL,
   },
   [Environment.DEV]: {
-    apiUrl: '',
+    apiUrl: "",
     environment: Environment.DEV,
   },
   [Environment.STAGING]: {
-    apiUrl: '',
+    apiUrl: "",
     environment: Environment.STAGING,
   },
   [Environment.PROD]: {
-    apiUrl: '',
+    apiUrl: "",
     environment: Environment.PROD,
   },
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,16 +4,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-const path = require('path');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const GitRevisionPlugin = require('git-revision-webpack-plugin');
-const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+const path = require("path");
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const GitRevisionPlugin = require("git-revision-webpack-plugin");
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+const BundleAnalyzerPlugin = require("webpack-bundle-analyzer")
   .BundleAnalyzerPlugin;
-const webpack = require('webpack');
+const webpack = require("webpack");
 
-const packageJson = require('./package.json');
+const packageJson = require("./package.json");
 
 const smp = new SpeedMeasurePlugin({
   disable: !process.env.MEASURE,
@@ -23,68 +23,68 @@ module.exports = (env) => {
   const isProd = env && env.production;
 
   const config = {
-    entry: './src/index.tsx',
+    entry: "./src/index.tsx",
     module: {
       rules: [
         {
           test: /\.(ts|tsx)$/,
-          use: 'ts-loader',
-          include: path.resolve(__dirname, 'src'),
+          use: "ts-loader",
+          include: path.resolve(__dirname, "src"),
         },
         {
           test: /\.(svg|png)$/i,
-          use: 'url-loader',
+          use: "url-loader",
         },
         {
           test: /(?<!\.module)\.css$/,
-          include: path.resolve(__dirname, 'src'),
-          use: ['style-loader', 'css-loader', 'postcss-loader'],
+          include: path.resolve(__dirname, "src"),
+          use: ["style-loader", "css-loader", "postcss-loader"],
         },
         {
           test: /\.module\.css$/,
           use: [
-            'style-loader',
+            "style-loader",
             {
-              loader: 'css-loader',
+              loader: "css-loader",
               options: {
                 importLoaders: 1,
                 modules: {
-                  localIdentName: '[name]__[local]__[hash:base64:5]',
+                  localIdentName: "[name]__[local]__[hash:base64:5]",
                 },
               },
             },
-            'postcss-loader',
+            "postcss-loader",
           ],
         },
       ],
     },
     resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx', '.css'],
+      extensions: [".js", ".jsx", ".ts", ".tsx", ".css"],
     },
     output: {
-      filename: '[name].[contentHash].js',
-      path: path.resolve(__dirname, 'build'),
+      filename: "[name].[contentHash].js",
+      path: path.resolve(__dirname, "build"),
     },
     optimization: {
       splitChunks: {
-        chunks: 'all',
-        automaticNameDelimiter: '-',
+        chunks: "all",
+        automaticNameDelimiter: "-",
       },
       runtimeChunk: {
-        name: 'manifest',
+        name: "manifest",
       },
     },
     plugins: [
       new CleanWebpackPlugin(),
       new HtmlWebpackPlugin({
-        template: './src/index.html',
+        template: "./src/index.html",
       }),
       new webpack.DefinePlugin({
         __BUILD_INFO__: JSON.stringify({
           appName: packageJson.name,
           appBuildTime: new Date().toISOString(),
           commitHash: new GitRevisionPlugin({
-            commithashCommand: 'rev-parse --short HEAD',
+            commithashCommand: "rev-parse --short HEAD",
           }).commithash(),
         }),
       }),
@@ -94,11 +94,11 @@ module.exports = (env) => {
   if (isProd) {
     return smp.wrap({
       ...config,
-      mode: 'production',
-      devtool: 'source-map',
+      mode: "production",
+      devtool: "source-map",
       performance: {
         // https://web.dev/your-first-performance-budget/#budget-for-quantity-based-metrics
-        hints: 'warning',
+        hints: "warning",
         maxEntrypointSize: 170 * 1024,
         maxAssetSize: 450 * 1024,
       },
@@ -107,7 +107,7 @@ module.exports = (env) => {
         process.env.ANALYZE &&
           new BundleAnalyzerPlugin({
             generateStatsFile: true,
-            analyzerMode: 'disabled',
+            analyzerMode: "disabled",
           }),
       ].filter(Boolean),
     });
@@ -116,10 +116,10 @@ module.exports = (env) => {
   // Configuration specific to developing locally
   return smp.wrap({
     ...config,
-    mode: 'development',
-    devtool: 'eval-source-map',
+    mode: "development",
+    devtool: "eval-source-map",
     devServer: {
-      contentBase: './build',
+      contentBase: "./build",
       port: 3000,
       historyApiFallback: true,
     },
@@ -127,9 +127,9 @@ module.exports = (env) => {
       rules: [
         ...config.module.rules,
         {
-          enforce: 'pre',
+          enforce: "pre",
           test: /\.*js$/,
-          loader: 'source-map-loader',
+          loader: "source-map-loader",
         },
       ],
     },


### PR DESCRIPTION
Jeg har nok personlig gått bort fra bruk av singlequotes en god del. Rationalet her er også å fjerne en overstyring fra configen, samt at JSX quoting faktisk er double quotes, siden vi ikke har overstyrt det.

Det er jo egentlig ikke nøye at dette er konsistent på tvers av løsninger, Prettier gjør jo det behovet unødvendig. Men som en default foreslår jeg å bruke default til Prettier, og samkjøre det med JSX.